### PR TITLE
Fix possible array exception | Mimic style

### DIFF
--- a/scripting/selfgag.sp
+++ b/scripting/selfgag.sp
@@ -293,11 +293,11 @@ public Action OnChatMessage(int &i_author, Handle h_recipients, char[] s_name, c
 			return Plugin_Stop;
 		}
 	}
-	for (int i = 0; i < i_recipients; i++)
+	for (int i = i_recipients - 1; i >= 0; i--)
 	{
 		if (!ShouldRecipientReadFromSender(GetArrayCell(h_recipients, i), i_author))
 		{	
-			(view_as<ArrayList>(h_recipients)).Erase(i);
+			RemoveFromArray(h_recipients, i);
 		}
 	}
 	return Plugin_Continue;


### PR DESCRIPTION
If you remove an index from an array, the lenght changes and you probably access a non-existend indexes at the end.
Reverse the for-loop, so we dont have to worry about accessing non-existend indexes.
Also, use old native method instead of methodmap method to mimic code style.